### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ After successful installation of *nextcloud-integration* app You can search for 
 
 <kbd><img src=".github/nextcloud_setting_screen.png" alt="NextCloud Setting Screen" /></kbd>
 
-* **Email**: Email address of your *Nextcloud Account*
+* **Username**: Your *Nextcloud Account Username*
 * **Password**: Your *Nextcloud Account password* or *App Password* you might have created for this app.
 * **Nextcloud URL**: URL of site where Nextcloud Account exist. *For eg("https://example.com")*.
 Optionally you can also provide a port number after your URL as *("https://example.com:443")*


### PR DESCRIPTION
If https://github.com/frappe/nextcloud-integration/pull/14 goes through then this description should be edited.

Nextcloud does not require an e-mail address to create a user.
![image](https://user-images.githubusercontent.com/22279621/101289123-d207a480-37fa-11eb-90c4-f5eb21f31030.png)
